### PR TITLE
[Feat] BaseResponse 작성

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/BaseResponse.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/BaseResponse.java
@@ -1,0 +1,28 @@
+package com.beyond.synclab.ctrlline.common.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class BaseResponse<T> {
+    private final int code;
+    private final T data;
+
+    public static <T> BaseResponse<T> ok(T data) {
+        return BaseResponse.<T>builder()
+            .code(200)
+            .data(data)
+            .build();
+    }
+
+    public static <T> BaseResponse<T> of(int code, T data) {
+        return BaseResponse.<T>builder()
+            .code(code)
+            .data(data)
+            .build();
+    }
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/PageInfoDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/PageInfoDto.java
@@ -1,0 +1,30 @@
+package com.beyond.synclab.ctrlline.common.dto;
+
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageInfoDto {
+    private final int currentPage;
+    private final int pageSize;
+    private final int totalPages;
+    private final long totalElements;
+    private final List<SortDto> sort;
+
+    public static <T> PageInfoDto from(Page<T> page) {
+        return PageInfoDto.builder()
+            .currentPage(page.getNumber() + 1) // 0-based → 1-based
+            .pageSize(page.getSize())
+            .totalPages(page.getTotalPages())
+            .totalElements(page.getTotalElements())
+            .sort(SortDto.from(page.getSort()))
+            .build();
+    }
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/PageResponse.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/PageResponse.java
@@ -1,0 +1,23 @@
+package com.beyond.synclab.ctrlline.common.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+    private final List<T> content;       // 실제 데이터 목록
+    private final PageInfoDto pageInfo;
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+            .content(page.getContent())
+            .pageInfo(PageInfoDto.from(page))
+            .build();
+    }
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/SortDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/common/dto/SortDto.java
@@ -1,0 +1,34 @@
+package com.beyond.synclab.ctrlline.common.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SortDto {
+
+    private String sortBy;
+    private String direction;
+
+    // ✅ Sort.Order → SortDto 변환 생성자
+    public static SortDto from(Sort.Order order) {
+        return SortDto.builder()
+            .sortBy(order.getProperty())
+            .direction(order.getDirection().name().toLowerCase())
+            .build();
+    }
+
+    // ✅ Sort → List<SortDto> 변환
+    public static List<SortDto> from(Sort sort) {
+        return sort.stream()
+            .map(SortDto::from)
+            .toList();
+    }
+}


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

Response의 표준을 설정합니다.

---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)
- [x] BaseResponse 작성
- [x] PageResponse는 BaseResponse의 data가 page일때 작성

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `BaseResponse.java` | Response의 표준 작성 code랑 data |
| Backend | `PageResponse.java` | Response중 data부분이 Page관련된 데이터일때 사용 |
| Backend | `PageInfoDto.java` | Page정보 dto |
| Backend | `SortDto.java` | Sort 내용 dto |


---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #28
