### PR TITLE
[Feat] 생산실적 공장별 월별 6개월 누적 생산량 조회 구현 완료.

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/controller/ProductionPerformanceController.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/controller/ProductionPerformanceController.java
@@ -7,6 +7,7 @@ import com.beyond.synclab.ctrlline.domain.productionperformance.dto.request.Sear
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetAllProductionPerformanceResponseDto;
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceDetailResponseDto;
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceListResponseDto;
+import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceMonthlySumResponseDto;
 import com.beyond.synclab.ctrlline.domain.productionperformance.service.ProductionPerformanceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,5 +63,18 @@ public class ProductionPerformanceController {
         List<GetAllProductionPerformanceResponseDto> result =
                 productionPerformanceService.getAllProductionPerformances(condition);
         return ResponseEntity.ok(result);
+    }
+
+    // 공장별 월 생산량 조회
+    @GetMapping("/monthly")
+    public ResponseEntity<BaseResponse<GetProductionPerformanceMonthlySumResponseDto.FactoryMonthlyPerformance>>
+    getMonthlyProductionPerformance(
+            @RequestParam String factoryCode,
+            @RequestParam(required = false) String baseMonth
+    ) {
+        GetProductionPerformanceMonthlySumResponseDto.FactoryMonthlyPerformance result =
+                productionPerformanceService.getMonthlySumProductionPerformances(factoryCode, baseMonth);
+
+        return ResponseEntity.ok(ok(result));
     }
 }

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceMonthlySumResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceMonthlySumResponseDto.java
@@ -1,0 +1,58 @@
+package com.beyond.synclab.ctrlline.domain.productionperformance.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetProductionPerformanceMonthlySumResponseDto {
+
+    // 2025-11 같은 형태의 기준 월
+    private String month;
+
+    // 해당 월의 총 생산량(누적)
+    private Long totalPerformanceQty;
+
+    public static GetProductionPerformanceMonthlySumResponseDto of(
+            String month,
+            Long totalPerformanceQty
+    ) {
+        return GetProductionPerformanceMonthlySumResponseDto.builder()
+                .month(month)
+                .totalPerformanceQty(totalPerformanceQty)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FactoryMonthlyPerformance {
+
+        private String factoryCode;
+        private String factoryName;
+
+        @JsonProperty("performances")
+        private List<GetProductionPerformanceMonthlySumResponseDto> performances;
+
+        public static FactoryMonthlyPerformance of(
+                String factoryCode,
+                String factoryName,
+                List<GetProductionPerformanceMonthlySumResponseDto> performances
+        ) {
+            return FactoryMonthlyPerformance.builder()
+                    .factoryCode(factoryCode)
+                    .factoryName(factoryName)
+                    .performances(performances)
+                    .build();
+        }
+    }
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceMonthlyQueryRepository.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceMonthlyQueryRepository.java
@@ -1,0 +1,10 @@
+package com.beyond.synclab.ctrlline.domain.productionperformance.repository.query;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+public interface ProductionPerformanceMonthlyQueryRepository {
+
+    Map<YearMonth, Long> getMonthlySum(String factoryCode, List<YearMonth> months);
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceMonthlyQueryRepositoryImpl.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceMonthlyQueryRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.beyond.synclab.ctrlline.domain.productionperformance.repository.query;
+
+import com.beyond.synclab.ctrlline.domain.itemline.entity.QItemsLines;
+import com.beyond.synclab.ctrlline.domain.line.entity.QLines;
+import com.beyond.synclab.ctrlline.domain.productionperformance.entity.QProductionPerformances;
+import com.beyond.synclab.ctrlline.domain.productionplan.entity.QProductionPlans;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ProductionPerformanceMonthlyQueryRepositoryImpl
+        implements ProductionPerformanceMonthlyQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<YearMonth, Long> getMonthlySum(String factoryCode, List<YearMonth> months) {
+
+        QProductionPerformances perf = QProductionPerformances.productionPerformances;
+        QProductionPlans plan = QProductionPlans.productionPlans;
+        QItemsLines itemLine = QItemsLines.itemsLines;
+        QLines line = QLines.lines;
+
+        // "YYYY-MM" 리스트
+        List<String> monthStrings = months.stream()
+                .map(YearMonth::toString)
+                .toList();
+
+        // YYYY/MM → YYYY-MM
+        // substring + replace 적용
+        StringExpression ymExpr = Expressions.stringTemplate(
+                "replace(substring({0}, 1, 7), '/', '-')",
+                perf.performanceDocumentNo
+        );
+
+        // DB에서 BigDecimal SUM → 이후 Java에서 Long 변환
+        NumberExpression<BigDecimal> sumExpr =
+                Expressions.numberTemplate(BigDecimal.class, "sum({0})", perf.performanceQty);
+
+        List<Tuple> result = queryFactory
+                .select(
+                        ymExpr.as("month"),
+                        sumExpr
+                )
+                .from(perf)
+                .leftJoin(perf.productionPlan, plan)
+                .leftJoin(plan.itemLine, itemLine)
+                .leftJoin(itemLine.line, line)
+                .where(
+                        line.factory.factoryCode.eq(factoryCode),
+                        ymExpr.in(monthStrings)
+                )
+                .groupBy(ymExpr)
+                .fetch();
+
+        Map<YearMonth, Long> sumByMonth = new HashMap<>();
+
+        for (Tuple tuple : result) {
+
+            String ym = tuple.get(0, String.class);
+
+            // Long 변환 방식
+            BigDecimal totalDecimal = tuple.get(1, BigDecimal.class);
+            Long total = (totalDecimal != null) ? totalDecimal.longValue() : 0L;
+
+            if (ym != null) {
+                sumByMonth.put(YearMonth.parse(ym), total);
+            }
+        }
+
+        return sumByMonth;
+    }
+}

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/service/ProductionPerformanceService.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/service/ProductionPerformanceService.java
@@ -5,6 +5,7 @@ import com.beyond.synclab.ctrlline.domain.productionperformance.dto.request.Sear
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetAllProductionPerformanceResponseDto;
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceDetailResponseDto;
 import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceListResponseDto;
+import com.beyond.synclab.ctrlline.domain.productionperformance.dto.response.GetProductionPerformanceMonthlySumResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -19,10 +20,16 @@ public interface ProductionPerformanceService {
     );
 
     // 생산실적 상세 조회
-    GetProductionPerformanceDetailResponseDto getProductionPerformanceDetail(Long id);
+    GetProductionPerformanceDetailResponseDto getProductionPerformanceDetail(
+            Long id
+    );
 
     // 생산실적 현황 조회
     List<GetAllProductionPerformanceResponseDto> getAllProductionPerformances(
             SearchAllProductionPerformanceRequestDto condition
     );
+
+    // 공장별 월별 생산량 조회 (대시보드)
+    GetProductionPerformanceMonthlySumResponseDto.FactoryMonthlyPerformance
+    getMonthlySumProductionPerformances(String factoryCode, String baseMonth);
 }

--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionperformance/ProductionPerformanceMonthlyQueryRepositoryTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionperformance/ProductionPerformanceMonthlyQueryRepositoryTest.java
@@ -1,0 +1,258 @@
+package com.beyond.synclab.ctrlline.domain.productionperformance;
+
+import com.beyond.synclab.ctrlline.domain.factory.entity.Factories;
+import com.beyond.synclab.ctrlline.domain.item.entity.Items;
+import com.beyond.synclab.ctrlline.domain.item.entity.enums.ItemStatus;
+import com.beyond.synclab.ctrlline.domain.itemline.entity.ItemsLines;
+import com.beyond.synclab.ctrlline.domain.line.entity.Lines;
+import com.beyond.synclab.ctrlline.domain.productionperformance.entity.ProductionPerformances;
+import com.beyond.synclab.ctrlline.domain.productionperformance.repository.query.ProductionPerformanceMonthlyQueryRepositoryImpl;
+import com.beyond.synclab.ctrlline.domain.productionplan.entity.ProductionPlans;
+import com.beyond.synclab.ctrlline.domain.user.entity.Users;
+import config.QuerydslTestConfig;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QuerydslTestConfig.class, ProductionPerformanceMonthlyQueryRepositoryImpl.class})
+class ProductionPerformanceMonthlyQueryRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ProductionPerformanceMonthlyQueryRepositoryImpl monthlyRepository;
+
+    private Factories factory;
+    private Lines line;
+    private Items itemA;
+    private Items itemB;
+    private ItemsLines itemLineA;
+    private ItemsLines itemLineB;
+    private Users salesManager;
+    private Users prodManager;
+
+    @BeforeEach
+    void setUp() {
+
+        // ---------- Factory ----------
+        factory = Factories.builder()
+                .factoryCode("F001")
+                .factoryName("테스트공장")
+                .isActive(true)
+                .build();
+        em.persist(factory);
+
+        // ---------- Line ----------
+        line = Lines.builder()
+                .factory(factory)
+                .factoryId(factory.getId())
+                .lineCode("L01")
+                .lineName("1라인")
+                .isActive(true)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        em.persist(line);
+
+        // ---------- Items ----------
+        itemA = Items.builder()
+                .itemCode("ITEM-A")
+                .itemName("제품A")
+                .itemStatus(ItemStatus.RAW_MATERIAL)
+                .itemUnit("EA")
+                .isActive(true)
+                .build();
+        em.persist(itemA);
+
+        itemB = Items.builder()
+                .itemCode("ITEM-B")
+                .itemName("제품B")
+                .itemStatus(ItemStatus.FINISHED_PRODUCT)
+                .itemUnit("EA")
+                .isActive(true)
+                .build();
+        em.persist(itemB);
+
+        // ---------- Item-Lines ----------
+        itemLineA = ItemsLines.builder()
+                .line(line)
+                .lineId(line.getId())
+                .item(itemA)
+                .itemId(itemA.getId())
+                .build();
+        em.persist(itemLineA);
+
+        itemLineB = ItemsLines.builder()
+                .line(line)
+                .lineId(line.getId())
+                .item(itemB)
+                .itemId(itemB.getId())
+                .build();
+        em.persist(itemLineB);
+
+        // ---------- Users ----------
+        salesManager = Users.builder()
+                .empNo("E1000")
+                .name("홍길동")
+                .email("hong@test.com")
+                .password("1234")
+                .phoneNumber("010-1111-2222")
+                .hiredDate(LocalDate.now())
+                .role(Users.UserRole.USER)
+                .status(Users.UserStatus.ACTIVE)
+                .department("영업부")
+                .position(Users.UserPosition.ASSISTANT)
+                .address("서울시")
+                .build();
+        em.persist(salesManager);
+
+        prodManager = Users.builder()
+                .empNo("E2000")
+                .name("김철수")
+                .email("kim@test.com")
+                .password("1234")
+                .phoneNumber("010-3333-4444")
+                .hiredDate(LocalDate.now())
+                .role(Users.UserRole.USER)
+                .status(Users.UserStatus.ACTIVE)
+                .department("생산부")
+                .position(Users.UserPosition.ASSISTANT_MANAGER)
+                .address("경기도")
+                .build();
+        em.persist(prodManager);
+
+        // ---------- ProductionPlans ----------
+        ProductionPlans planA = ProductionPlans.builder()
+                .documentNo("2025/11/18-1")
+                .itemLine(itemLineA)
+                .itemLineId(itemLineA.getId())
+                .salesManager(salesManager)
+                .salesManagerId(salesManager.getId())
+                .productionManager(prodManager)
+                .productionManagerId(prodManager.getId())
+                .dueDate(LocalDate.now())
+                .plannedQty(BigDecimal.valueOf(100))
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .build();
+        em.persist(planA);
+
+        ProductionPlans planB = ProductionPlans.builder()
+                .documentNo("2025/12/05-1")
+                .itemLine(itemLineB)
+                .itemLineId(itemLineB.getId())
+                .salesManager(salesManager)
+                .salesManagerId(salesManager.getId())
+                .productionManager(prodManager)
+                .productionManagerId(prodManager.getId())
+                .dueDate(LocalDate.now())
+                .plannedQty(BigDecimal.valueOf(200))
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .build();
+        em.persist(planB);
+
+        // ---------- ProductionPerformances ----------
+        em.persist(ProductionPerformances.builder()
+                .productionPlan(planA)
+                .productionPlanId(planA.getId())
+                .performanceDocumentNo("2025/11/18-1")
+                .totalQty(BigDecimal.valueOf(100))
+                .performanceQty(BigDecimal.valueOf(90))
+                .performanceDefectiveRate(BigDecimal.valueOf(10))
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .remark("test-A")
+                .build());
+
+        em.persist(ProductionPerformances.builder()
+                .productionPlan(planB)
+                .productionPlanId(planB.getId())
+                .performanceDocumentNo("2025/12/05-1")
+                .totalQty(BigDecimal.valueOf(200))
+                .performanceQty(BigDecimal.valueOf(180))
+                .performanceDefectiveRate(BigDecimal.valueOf(10))
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .remark("test-B")
+                .build());
+
+        em.flush();
+        em.clear();
+    }
+
+    // =============================================================
+    // 1. 단일 월 SUM 테스트
+    // =============================================================
+    @Test
+    @DisplayName("단일 월 생산량 SUM 정상 조회")
+    void testMonthlySum_singleMonth() {
+
+        Map<YearMonth, Long> result =
+                monthlyRepository.getMonthlySum(
+                        "F001",
+                        java.util.List.of(
+                                YearMonth.of(2025, 11)
+                        )
+                );
+
+        assertThat(result).containsEntry(YearMonth.of(2025, 11), 90L);
+    }
+
+    // =============================================================
+    // 2. 다중 월 SUM 테스트
+    // =============================================================
+    @Test
+    @DisplayName("여러 개월 SUM 조회 - 누적 결과 테스트")
+    void testMonthlySum_multipleMonths() {
+
+        Map<YearMonth, Long> result =
+                monthlyRepository.getMonthlySum(
+                        "F001",
+                        java.util.List.of(
+                                YearMonth.of(2025, 11),
+                                YearMonth.of(2025, 12)
+                        )
+                );
+
+        assertThat(result)
+                .containsAllEntriesOf(
+                        Map.of(
+                                YearMonth.of(2025, 11), 90L,
+                                YearMonth.of(2025, 12), 180L
+                        )
+                );
+    }
+
+    // =============================================================
+    // 3. 데이터 없는 월 테스트
+    // =============================================================
+    @Test
+    @DisplayName("데이터 없는 월은 null 또는 missing")
+    void testMonthlySum_emptyMonth() {
+
+        Map<YearMonth, Long> result =
+                monthlyRepository.getMonthlySum(
+                        "F001",
+                        java.util.List.of(
+                                YearMonth.of(2025, 10)     // 데이터 없음
+                        )
+                );
+
+        assertThat(result.containsKey(YearMonth.of(2025, 10))).isFalse();
+    }
+}


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.
생산실적 공장별 월별 6개월 누적 생산량 조회
---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)
- [x] 현재 월(baseMonth) 기준으로 0~5 범위 설정, asc으로 sort 하여 공장별 월별 6개월 누적 생산량 조회 기능 구현 완료
<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)
| Backend | 전용 dto, queryrepository, queryrepositoryimpl, 테스트 코드 생성
<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #166 
Fixes #166 
