### PR TITLE
[Feat] 불량 필터 조회 조건 추가

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/defective/dto/SearchDefectiveListRequestDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/defective/dto/SearchDefectiveListRequestDto.java
@@ -1,5 +1,6 @@
 package com.beyond.synclab.ctrlline.domain.defective.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import lombok.Builder;
 
@@ -7,6 +8,13 @@ import lombok.Builder;
 public record SearchDefectiveListRequestDto(
     LocalDate fromDate,
     LocalDate toDate,
-    String productionPerformanceDocNo
+    String productionPerformanceDocNo,
+    String defectiveDocNo,
+    String itemCode,
+    String itemName,
+    String lineCode,
+    String lineName,
+    BigDecimal defectiveQty,
+    BigDecimal defectiveRate
 ) {
 }

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/defective/repository/PlanDefectiveQueryRepositoryImpl.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/defective/repository/PlanDefectiveQueryRepositoryImpl.java
@@ -87,7 +87,14 @@ public class PlanDefectiveQueryRepositoryImpl implements PlanDefectiveQueryRepos
             .where(
                 createdAtTo(request.toDate()),
                 createdAtFrom(request.fromDate()),
-                performanceDocNoContains(request.productionPerformanceDocNo())
+                performanceDocNoContains(request.productionPerformanceDocNo()),
+                defectiveDocNoContains(request.defectiveDocNo()),
+                itemCodeContains(request.itemCode()),
+                itemNameContains(request.itemName()),
+                lineNameContains(request.lineName()),
+                lineCodeContains(request.lineCode()),
+                defectiveQtyEq(request.defectiveQty(), defectiveQtyExpr),
+                defectiveRateEq(request.defectiveRate())
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -102,7 +109,14 @@ public class PlanDefectiveQueryRepositoryImpl implements PlanDefectiveQueryRepos
             .where(
                 createdAtTo(request.toDate()),
                 createdAtFrom(request.fromDate()),
-                performanceDocNoContains(request.productionPerformanceDocNo())
+                performanceDocNoContains(request.productionPerformanceDocNo()),
+                defectiveDocNoContains(request.defectiveDocNo()),
+                itemCodeContains(request.itemCode()),
+                itemNameContains(request.itemName()),
+                lineNameContains(request.lineName()),
+                lineCodeContains(request.lineCode()),
+                defectiveQtyEq(request.defectiveQty(), defectiveQtyExpr),
+                defectiveRateEq(request.defectiveRate())
             );
 
         return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
@@ -198,6 +212,36 @@ public class PlanDefectiveQueryRepositoryImpl implements PlanDefectiveQueryRepos
             .factoryCode(factoryCode)
             .types(result)
             .build();
+    }
+
+    private BooleanExpression defectiveDocNoContains(String defectiveDocNo) {
+        return defectiveDocNo == null
+            ? null
+            : QPlanDefectives.planDefectives.defectiveDocumentNo.contains(defectiveDocNo);
+    }
+
+    private BooleanExpression itemCodeContains(String itemCode) {
+        return itemCode == null ? null : QItems.items.itemCode.contains(itemCode);
+    }
+
+    private BooleanExpression itemNameContains(String itemName) {
+        return itemName == null ? null : QItems.items.itemName.contains(itemName);
+    }
+
+    private BooleanExpression lineNameContains(String lineName) {
+        return lineName == null ? null : QLines.lines.lineName.contains(lineName);
+    }
+
+    private BooleanExpression lineCodeContains(String lineCode) {
+        return lineCode == null ? null : QLines.lines.lineCode.contains(lineCode);
+    }
+
+    private BooleanExpression defectiveQtyEq(BigDecimal qty, NumberExpression<BigDecimal> defectiveExpr) {
+        return qty == null ? null : defectiveExpr.eq(qty);
+    }
+
+    private BooleanExpression defectiveRateEq(BigDecimal rate) {
+        return rate == null ? null : QProductionPerformances.productionPerformances.performanceDefectiveRate.eq(rate);
     }
 
     private BooleanExpression createdAtFrom(LocalDate fromDate) {


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

불량 목록 조회시 필터 조건을 추가했습니다.

    String defectiveDocNo,
    String itemCode,
    String itemName,
    String lineCode,
    String lineName,
    BigDecimal defectiveQty,
    BigDecimal defectiveRate

---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #207
