### PR TITLE
[Fix] 생산실적 목록상세조회 DTO에 PK 추가

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceDetailResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceDetailResponseDto.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 @Builder
 public class GetProductionPerformanceDetailResponseDto {
 
+    private final Long id;
     private final String documentNo;
     private final String factoryCode;
     private final String factoryName;

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceListResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/dto/response/GetProductionPerformanceListResponseDto.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 @Builder
 public class GetProductionPerformanceListResponseDto {
 
+    private final Long id;
     private final String documentNo;
     private final String salesManagerNo;
     private final String productionManagerNo;

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceQueryRepositoryImpl.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/repository/query/ProductionPerformanceQueryRepositoryImpl.java
@@ -76,6 +76,7 @@ public class ProductionPerformanceQueryRepositoryImpl implements ProductionPerfo
         List<GetProductionPerformanceListResponseDto> results = queryFactory
                 .select(Projections.constructor(
                         GetProductionPerformanceListResponseDto.class,
+                        perf.id,
                         perf.performanceDocumentNo,
                         salesManager.empNo,
                         prodManager.empNo,

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/service/ProductionPerformanceServiceImpl.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionperformance/service/ProductionPerformanceServiceImpl.java
@@ -81,6 +81,7 @@ public class ProductionPerformanceServiceImpl implements ProductionPerformanceSe
                 .orElseThrow(LotNotFoundException::new);
 
         return GetProductionPerformanceDetailResponseDto.builder()
+                .id(perf.getId())
                 .documentNo(perf.getPerformanceDocumentNo())
 
                 .factoryCode(factory.getFactoryCode())
@@ -252,7 +253,7 @@ public class ProductionPerformanceServiceImpl implements ProductionPerformanceSe
         // remark 필드가 요청에 존재하는 경우에만 수정
         perf.updateRemark(remark);
 
-        // 여기! 다시 DB에서 조회해서 DTO 변환
+        // 다시 DB에서 조회해서 DTO 변환
         ProductionPerformances updated = performanceRepository.findById(id)
                 .orElseThrow(ProductionPerformanceNotFoundException::new);
 

--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionperformance/ProductionPerformanceServiceTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionperformance/ProductionPerformanceServiceTest.java
@@ -158,6 +158,7 @@ class ProductionPerformanceServiceTest {
 
         // then
         assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(perfId);
         assertThat(response.getDocumentNo()).isEqualTo("2099/01/01-1");
         assertThat(response.getFactoryCode()).isEqualTo("F001");
         assertThat(response.getLineCode()).isEqualTo("L01");


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.
생산실적 목록상세조회 DTO에 PK 추가
---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #231 
Fixes #231 
