### PR TITLE
[Feat] 설비목록조회 리스폰스에 line_id 추가

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/dto/EquipmentSearchResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/dto/EquipmentSearchResponseDto.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 
 public class EquipmentSearchResponseDto {
+        private final Long lineId;
         private final String equipmentCode;
         private final String equipmentName;
         private final String equipmentType;
@@ -29,6 +30,7 @@ public class EquipmentSearchResponseDto {
                 EquipmentRuntimeStatusLevel runtimeStatusLevel
         ) {
             return EquipmentSearchResponseDto.builder()
+                    .lineId(equipment.getLineId())
                     .equipmentCode(equipment.getEquipmentCode())
                     .equipmentName(equipment.getEquipmentName())
                     .equipmentType(equipment.getEquipmentType())

--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/equipment/controller/EquipmentControllerTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/equipment/controller/EquipmentControllerTest.java
@@ -166,6 +166,7 @@ class EquipmentControllerTest {
     void get_equipment_list_success() throws Exception {
         // given - 서비스가 반환할 가짜 DTO 준비
         EquipmentSearchResponseDto dto1 = EquipmentSearchResponseDto.builder()
+                .lineId(101L)
                 .equipmentCode("EQP-0001")
                 .equipmentName("절단기-01")
                 .equipmentType("공정설비")
@@ -175,6 +176,7 @@ class EquipmentControllerTest {
                 .build();
 
         EquipmentSearchResponseDto dto2 = EquipmentSearchResponseDto.builder()
+                .lineId(102L)
                 .equipmentCode("EQP-0002")
                 .equipmentName("포장기-03")
                 .equipmentType("포장설비")
@@ -202,6 +204,7 @@ class EquipmentControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.content[0].lineId").value(101))
                 .andExpect(jsonPath("$.data.content[0].equipmentCode").value("EQP-0001"))
                 .andExpect(jsonPath("$.data.content[1].equipmentCode").value("EQP-0002"));
     }


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

--- 설비 목록조회 리스폰스에 설비별 소속line_id를 포함시킵니다.

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #252 
