### PR TITLE
[Feat] 설비 공정 목록조회 리스폰스 id 추가

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/dto/EquipmentSearchResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/dto/EquipmentSearchResponseDto.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 
 public class EquipmentSearchResponseDto {
+        private final Long equipmentId;
         private final Long lineId;
         private final String equipmentCode;
         private final String equipmentName;
@@ -30,6 +31,7 @@ public class EquipmentSearchResponseDto {
                 EquipmentRuntimeStatusLevel runtimeStatusLevel
         ) {
             return EquipmentSearchResponseDto.builder()
+                    .equipmentId(equipment.getId())
                     .lineId(equipment.getLineId())
                     .equipmentCode(equipment.getEquipmentCode())
                     .equipmentName(equipment.getEquipmentName())

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/process/dto/SearchProcessResponseDto.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/process/dto/SearchProcessResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 
 public class SearchProcessResponseDto {
+    private final Long processId;
     private final String processCode;
     private final String processName;
     private final String userDepartment;
@@ -21,6 +22,7 @@ public class SearchProcessResponseDto {
 
     public static SearchProcessResponseDto fromEntity (Processes process, Users user) {
         return SearchProcessResponseDto.builder()
+                .processId(process.getId())
                 .processCode(process.getProcessCode())
                 .processName(process.getProcessName())
                 .userDepartment(user.getDepartment())


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

--- 설비와 공정의 목록조회 시 id값을 리스폰스에 포함시킵니다.

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #252 
