### PR TITLE
[Refactor] 설비코드 추적 로직 보강

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/repository/EquipmentRepository.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/repository/EquipmentRepository.java
@@ -50,4 +50,7 @@ public interface EquipmentRepository extends JpaRepository<Equipments, Long>, Eq
             where e.equipmentCode = :equipmentCode
             """)
     Optional<EquipmentLocation> findLocationByEquipmentCode(String equipmentCode);
+
+    @Query("select e from Equipments e where upper(e.equipmentCode) like upper(concat(:codePrefix, '%')) order by e.equipmentCode")
+    List<Equipments> findAllByEquipmentCodePrefix(String codePrefix);
 }


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

--- 설비코드의 구체적인 매핑을 보강했습니다.

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #298
