### PR TITLE
[Fix] 불량 저장 로직 수정

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/telemetry/service/MesProductionPerformanceService.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/telemetry/service/MesProductionPerformanceService.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -84,55 +83,6 @@ public class MesProductionPerformanceService {
                 productionPlan.getDocumentNo());
 
         productionOrderService.sendLineAck(productionPlan);
-    }
-
-    @Transactional
-    public void updateRunningProgress(String orderNo, BigDecimal producedQty, BigDecimal ngQty) {
-        if (!StringUtils.hasText(orderNo)) {
-            log.warn("orderNo가 없어 진행중 생산실적을 갱신하지 않습니다.");
-            return;
-        }
-
-        Optional<ProductionPlans> planOptional = productionPlanResolver.resolveLatestPlan(orderNo);
-        if (planOptional.isEmpty()) {
-            log.warn("전표번호에 해당하는 생산계획을 찾을 수 없어 진행중 생산실적을 갱신하지 않습니다. orderNo={}", orderNo);
-            return;
-        }
-        ProductionPlans productionPlan = planOptional.get();
-
-        BigDecimal normalizedProduced = normalizeQuantity(producedQty);
-        BigDecimal normalizedNg = normalizeQuantity(Optional.ofNullable(ngQty).orElse(BigDecimal.ZERO));
-        BigDecimal totalQty = normalizeQuantity(productionPlan.getPlannedQty());
-        BigDecimal defectiveRate = calculateDefectiveRate(totalQty, normalizedNg);
-        LocalDateTime now = LocalDateTime.now(clock);
-        LocalDateTime startTime = Optional.ofNullable(productionPlan.getStartTime()).orElse(now);
-
-        ProductionPerformances performance = productionPerformanceRepository
-                .findByProductionPlanId(productionPlan.getId())
-                .map(existing -> {
-                    existing.updatePerformance(
-                            totalQty,
-                            normalizedProduced,
-                            defectiveRate,
-                            startTime,
-                            now
-                    );
-                    return existing;
-                })
-                .orElseGet(() -> ProductionPerformances.builder()
-                        .productionPlan(productionPlan)
-                        .productionPlanId(productionPlan.getId())
-                        .performanceDocumentNo(createDocumentNo())
-                        .totalQty(totalQty)
-                        .performanceQty(normalizedProduced)
-                        .performanceDefectiveRate(defectiveRate)
-                        .startTime(startTime)
-                        .endTime(now)
-                        .remark(null)
-                        .isDeleted(Boolean.FALSE)
-                        .build());
-
-        productionPerformanceRepository.save(performance);
     }
 
     private BigDecimal normalizeQuantity(BigDecimal quantity) {

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/telemetry/service/MesTelemetryListener.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/telemetry/service/MesTelemetryListener.java
@@ -400,10 +400,6 @@ public class MesTelemetryListener {
                 payload.defectiveQuantity());
         mesDefectiveService.saveOrderSummaryTelemetry(payload);
         lineFinalInspectionProgressService.updateFromSummary(payload);
-        mesProductionPerformanceService.updateRunningProgress(
-                payload.orderNo(),
-                payload.producedQuantity(),
-                payload.defectiveQuantity());
     }
 
     private void persistEquipmentState(JsonNode valueNode, String recordKey) {


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

--- 불량 및 실적 관련 데이터 저장 로직을 단일화 하였습니다.

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

- order_summary_payload를 통하여 실적 데이터 접근 로직 삭제
- production_performance_payload 단일화 

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #313
