### PR TITLE
[Fix] Hold, Suspend 상태 알람 연계 수정

### DIFF
--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/equipment/service/EquipmentRuntimeStatusServiceTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/equipment/service/EquipmentRuntimeStatusServiceTest.java
@@ -72,6 +72,21 @@ class EquipmentRuntimeStatusServiceTest {
     }
 
     @Test
+    void updateStatus_holdWithoutActiveAlarmUsesAlarmLevel() {
+        EquipmentStatusTelemetryPayload payload = new EquipmentStatusTelemetryPayload(
+                "EQP-105",
+                "HOLD",
+                "CRITICAL",
+                false,
+                null
+        );
+
+        service.updateStatus(payload);
+
+        assertThat(service.getLevelOrDefault("EQP-105")).isEqualTo(EquipmentRuntimeStatusLevel.HIGH_WARNING);
+    }
+
+    @Test
     void updateStatus_marksNoticeAlarmAsLightWarning() {
         EquipmentStatusTelemetryPayload payload = new EquipmentStatusTelemetryPayload(
                 "EQP-103",
@@ -99,6 +114,21 @@ class EquipmentRuntimeStatusServiceTest {
         service.updateStatus(payload);
 
         assertThat(service.getLevelOrDefault("EQP-104")).isEqualTo(EquipmentRuntimeStatusLevel.HIGH_WARNING);
+    }
+
+    @Test
+    void updateStatus_suspendStateDefaultsToLowWarningWhenAlarmLevelMissing() {
+        EquipmentStatusTelemetryPayload payload = new EquipmentStatusTelemetryPayload(
+                "EQP-106",
+                "SUSPEND",
+                null,
+                false,
+                null
+        );
+
+        service.updateStatus(payload);
+
+        assertThat(service.getLevelOrDefault("EQP-106")).isEqualTo(EquipmentRuntimeStatusLevel.LOW_WARNING);
     }
 
     @Test


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

--- 설비가 Hold와 Suspend인 경우의 SSE 응답을 수정하였습니다.

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #361
