### PR TITLE
[Fix] 설비가 비활성화되면 계획등록, 수정 못하도록 계산 validation 추가

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/repository/EquipmentRepository.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/equipment/repository/EquipmentRepository.java
@@ -24,7 +24,7 @@ public interface EquipmentRepository extends JpaRepository<Equipments, Long>, Eq
     // 설비코드 중복 여부 확인
     boolean existsByEquipmentCode(String equipmentCode);
 
-    List<Equipments> findAllByLineIdAndIsActiveTrue(Long lineId);
+    List<Equipments> findAllByLineId(Long lineId);
 
     @Query("""
             select e from Equipments e

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionplan/service/ProductionPlanServiceImpl.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/productionplan/service/ProductionPlanServiceImpl.java
@@ -311,7 +311,9 @@ public class ProductionPlanServiceImpl implements ProductionPlanService {
 
         activationValidator.validateItemActive(item);
 
-        List<Equipments> processingEquips = equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId());
+        List<Equipments> processingEquips = equipmentRepository.findAllByLineId(line.getId());
+
+        activationValidator.validateEquipmentActive(processingEquips);
 
         ItemsLines itemsLines = itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId())
                 .orElseThrow(() -> {
@@ -795,7 +797,8 @@ public class ProductionPlanServiceImpl implements ProductionPlanService {
         }
 
         // 수량 변경 → 종료시간 재계산 필요
-        List<Equipments> equips = equipmentRepository.findAllByLineIdAndIsActiveTrue(lineId);
+        List<Equipments> equips = equipmentRepository.findAllByLineId(lineId);
+        activationValidator.validateEquipmentActive(equips);
 
         return calculateEndTime(lineId, equips, dto.getPlannedQty(), newStart);
     }
@@ -1087,7 +1090,8 @@ public class ProductionPlanServiceImpl implements ProductionPlanService {
         Lines line = lineRepository.findBylineCodeAndIsActiveTrue(requestDto.getLineCode())
             .orElseThrow(() -> new AppException(LineErrorCode.LINE_NOT_FOUND));
 
-        List<Equipments> equipments =  equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId());
+        List<Equipments> equipments =  equipmentRepository.findAllByLineId(line.getId());
+        activationValidator.validateEquipmentActive(equipments);
 
         LocalDateTime endTime =
             calculateEndTime(line.getId(), equipments, requestDto.getPlannedQty(), requestDto.getStartTime());

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/validator/DomainActivationValidator.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/validator/DomainActivationValidator.java
@@ -13,6 +13,8 @@ import com.beyond.synclab.ctrlline.domain.line.errorcode.LineErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class DomainActivationValidator {
@@ -36,9 +38,9 @@ public class DomainActivationValidator {
         }
     }
 
-    public void validateEquipmentActive(Equipments equipment) {
-        validateLineActive(equipment.getLine());
-        if (!equipment.isActivated()) {
+    public void validateEquipmentActive(List<Equipments> equipments) {
+        validateLineActive(equipments.getFirst().getLine());
+        if (equipments.stream().anyMatch(eq -> !eq.isActivated())) {
             throw new AppException(LineErrorCode.EQUIPMENT_INACTIVE);
         }
     }

--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionplan/service/ProductionPlanServiceImplTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/productionplan/service/ProductionPlanServiceImplTest.java
@@ -278,7 +278,7 @@ class ProductionPlanServiceImplTest {
             when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId()))
                 .thenReturn(Optional.of(itemsLines));
 
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId()))
+            when(equipmentRepository.findAllByLineId(line.getId()))
                 .thenReturn(List.of(equipment));
 
             // 최근계획 없음
@@ -354,7 +354,7 @@ class ProductionPlanServiceImplTest {
             when(lineRepository.findBylineCodeAndIsActiveTrue(line.getLineCode())).thenReturn(Optional.of(line));
             when(itemRepository.findByItemCodeAndIsActiveTrue(item.getItemCode())).thenReturn(Optional.of(item));
             when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId())).thenReturn(Optional.of(itemsLines));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId())).thenReturn(Collections.emptyList());
+            when(equipmentRepository.findAllByLineId(line.getId())).thenReturn(Collections.emptyList());
 
             assertThatThrownBy(() -> productionPlanService.createProductionPlan(dto, requestUser))
                 .isInstanceOf(AppException.class)
@@ -379,7 +379,7 @@ class ProductionPlanServiceImplTest {
             when(lineRepository.findBylineCodeAndIsActiveTrue(line.getLineCode())).thenReturn(Optional.of(line));
             when(itemRepository.findByItemCodeAndIsActiveTrue(item.getItemCode())).thenReturn(Optional.of(item));
             when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId())).thenReturn(Optional.of(itemsLines));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId())).thenReturn(List.of(ppmZeroEquipment));
+            when(equipmentRepository.findAllByLineId(line.getId())).thenReturn(List.of(ppmZeroEquipment));
 
             assertThatThrownBy(() -> productionPlanService.createProductionPlan(dto, requestUser))
                 .isInstanceOf(AppException.class)
@@ -405,7 +405,7 @@ class ProductionPlanServiceImplTest {
             when(itemRepository.findByItemCodeAndIsActiveTrue(item.getItemCode())).thenReturn(Optional.of(item));
             when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId()))
                 .thenReturn(Optional.of(itemsLines));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId())).thenReturn(List.of(equipment));
+            when(equipmentRepository.findAllByLineId(line.getId())).thenReturn(List.of(equipment));
             when(productionPlanRepository.findAllByLineIdAndStatusesOrderByStartTimeAsc(
                 eq(line.getId()), anyList()
             )).thenReturn(List.of(existingPlan));
@@ -490,7 +490,7 @@ class ProductionPlanServiceImplTest {
             when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId()))
                 .thenReturn(Optional.of(itemsLines));
 
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId()))
+            when(equipmentRepository.findAllByLineId(line.getId()))
                 .thenReturn(List.of(equipment));
 
             // 기존 계획이 하나 있다고 가정 → shift 발생 여부 검증 가능
@@ -545,7 +545,7 @@ class ProductionPlanServiceImplTest {
                 .thenReturn(Optional.of(item));
             lenient().when(itemLineRepository.findByLineIdAndItemIdAndIsActiveTrue(line.getId(), item.getId()))
                 .thenReturn(Optional.of(itemsLines));
-            lenient().when(equipmentRepository.findAllByLineIdAndIsActiveTrue(line.getId()))
+            lenient().when(equipmentRepository.findAllByLineId(line.getId()))
                 .thenReturn(List.of(equipment));
         }
 
@@ -1551,7 +1551,7 @@ class ProductionPlanServiceImplTest {
                 .build();
 
             when(lineRepository.findBylineCodeAndIsActiveTrue("LINE001")).thenReturn(Optional.of(line));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(1L)).thenReturn(List.of(eq1, eq2));
+            when(equipmentRepository.findAllByLineId(1L)).thenReturn(List.of(eq1, eq2));
 
             // when
             GetProductionPlanEndTimeResponseDto response = productionPlanService.getProductionPlanEndTime(request);
@@ -1594,7 +1594,7 @@ class ProductionPlanServiceImplTest {
                 .build();
 
             when(lineRepository.findBylineCodeAndIsActiveTrue("LINE001")).thenReturn(Optional.of(line));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(1L)).thenReturn(List.of(eq1, eq2));
+            when(equipmentRepository.findAllByLineId(1L)).thenReturn(List.of(eq1, eq2));
             when(productionPerformanceRepository.findRecentByLineId(eq(line.getId()), any(Pageable.class)))
                 .thenReturn(List.of(performance));
 
@@ -1631,7 +1631,7 @@ class ProductionPlanServiceImplTest {
                 .build();
 
             when(lineRepository.findBylineCodeAndIsActiveTrue("LINE-1")).thenReturn(Optional.of(line));
-            when(equipmentRepository.findAllByLineIdAndIsActiveTrue(1L)).thenReturn(List.of());
+            when(equipmentRepository.findAllByLineId(1L)).thenReturn(List.of());
 
             assertThatThrownBy(() -> productionPlanService.getProductionPlanEndTime(request))
                 .isInstanceOf(AppException.class)


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

설비가 비활성화되면 계획등록, 수정 못하도록 계산 validation 추가

---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #369
Fixes #이슈번호
