### PR TITLE
[Feat] 완제품만 생산가능하도록 수정

### DIFF
--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/item/exception/ItemErrorCode.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/item/exception/ItemErrorCode.java
@@ -9,7 +9,8 @@ public enum ItemErrorCode implements ErrorCode {
 
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_NOT_FOUND", "해당 품목을 찾을 수 없습니다."),
     ITEMCODE_CONFLICT(HttpStatus.CONFLICT, "ITEMCODE_CONFLICT", "이미 존재하는 품목코드입니다."),
-    ITEM_INACTIVE(HttpStatus.BAD_REQUEST, "ITEM_INACTIVE", "비활성화된 품목입니다.");
+    ITEM_INACTIVE(HttpStatus.BAD_REQUEST, "ITEM_INACTIVE", "비활성화된 품목입니다."),
+    INVALID_ITEM_STATUS_FINISHED_PRODUCT(HttpStatus.BAD_REQUEST, "INVALID_ITEM_STATUS_FINISHED_PRODUCT", "품목(들)이 완제품이 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/itemline/repository/ItemLineRepository.java
+++ b/CtrlLine/src/main/java/com/beyond/synclab/ctrlline/domain/itemline/repository/ItemLineRepository.java
@@ -1,6 +1,7 @@
 package com.beyond.synclab.ctrlline.domain.itemline.repository;
 
 import com.beyond.synclab.ctrlline.domain.item.entity.Items;
+import com.beyond.synclab.ctrlline.domain.item.entity.enums.ItemStatus;
 import com.beyond.synclab.ctrlline.domain.itemline.entity.ItemsLines;
 import com.beyond.synclab.ctrlline.domain.line.entity.Lines;
 import java.util.List;
@@ -20,9 +21,9 @@ public interface ItemLineRepository extends JpaRepository<ItemsLines, Long> {
             WHERE il.line = :line
               AND il.isActive = true
               AND i.isActive = true
-              AND i.itemStatus = 'FINISHED_PRODUCT'
+              AND i.itemStatus = :status
     """)
-    List<Items> findActiveFinishedItemsByLine(@Param("line") Lines line);
+    List<Items> findActiveItemsByLineAndStatus(@Param("line") Lines line, @Param("status")ItemStatus status);
 
     List<ItemsLines> findByLine(Lines line);
 

--- a/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/itemline/ItemLineRepositoryTest.java
+++ b/CtrlLine/src/test/java/com/beyond/synclab/ctrlline/domain/itemline/ItemLineRepositoryTest.java
@@ -40,7 +40,7 @@ class ItemLineRepositoryTest {
 
     @Test
     @DisplayName("isActive=true && itemStatus=FINISHED_PRODUCT 인 품목만 조회되어야 한다")
-    void findActiveFinishedItemsByLine_shouldReturnOnlyActiveFinishedProducts() {
+    void findActiveFinishedItemsByLine_shouldReturnOnlyActiveProductsAndStatus() {
         // given
         // Line 생성
         Lines line = lineRepository.save(Lines.builder()
@@ -91,7 +91,7 @@ class ItemLineRepositoryTest {
                                           .build());
 
         // when
-        List<Items> result = itemLineRepository.findActiveFinishedItemsByLine(line);
+        List<Items> result = itemLineRepository.findActiveItemsByLineAndStatus(line, ItemStatus.FINISHED_PRODUCT);
 
         // then
         assertThat(result)


### PR DESCRIPTION
# 🔀 Pull Request

## 📌 개요

> 이번 PR의 목적을 간략히 설명해주세요.

라인에서 완제품만 조회, 등록, 수정가능하도록 개선

---

## 🧾 주요 변경 사항

> 핵심 변경 내용 요약 (코드 레벨 요약 중심)

<!-- 
예)
- [x] Kafka Consumer 적용하여 설비 데이터 스트림 처리
- [x] FastAPI ↔ Spring 간 비동기 통신 개선
- [x] DB 스키마 변경 (`work_log` 테이블 필드 추가)
- [ ] 테스트 코드 작성 (`EquipmentServiceTest`)
- [ ] CI/CD 파이프라인 수정
-->

---

## ⚙️ 변경 상세 내역

> 변경된 모듈별로 구체적 기술 (파일, 주요 로직 단위로)

<!-- 
예)
| 구분 | 경로 / 모듈 | 설명 |
|------|--------------|------|
| Backend | `EquipmentService.java` | Kafka 메시지 파싱 및 DB 저장 로직 추가 |
| Frontend | `EquipmentChart.vue` | 설비 상태 그래프 렌더링 추가 |
| DB | `V012__add_equipment_log_table.sql` | 로그 테이블 신규 생성 |
| Infra | `jenkinsfile` | build stage에 test 추가 |
-->

---

## 🧩 관련 이슈

> 관련된 Issue 번호를 반드시 연결하세요.

Closes #이슈번호
Fixes #이슈번호
